### PR TITLE
Fix eslint and tsc to be run from the project root

### DIFF
--- a/src/lint/linter/ArcanistESLintLinter.php
+++ b/src/lint/linter/ArcanistESLintLinter.php
@@ -27,7 +27,7 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
   }
 
   public function getVersion() {
-    $output = exec('./node_modules/.bin/eslint --version');
+    $output = exec(sprintf("%s --version", $this->getBinary()));
 
     if (strpos($output, 'command not found') !== false) {
       return false;

--- a/src/unit/engine/TypeScriptTestEngine.php
+++ b/src/unit/engine/TypeScriptTestEngine.php
@@ -10,8 +10,10 @@ final class TypeScriptTestEngine extends ArcanistUnitTestEngine {
   }
 
   public function run() {
+    $root = $this->getWorkingCopy()->getProjectRoot();
+    $tsc = Filesystem::resolvePath('./node_modules/.bin/tsc', $root);
     $time_start_seconds = microtime(true);
-    exec('./node_modules/.bin/tsc --project . --noEmit', $output, $return_var);
+    exec(sprintf("%s --project %s --noEmit", $tsc, $root), $output, $return_var);
     $time_taken_seconds = microtime(true) - $time_start_seconds;
 
     $result = new ArcanistUnitTestResult();


### PR DESCRIPTION
This fixes `arc diff` run in a subdirectory instead of the root.