### PR TITLE
Fix formatting for TypeScript errors

### DIFF
--- a/src/unit/engine/TypeScriptTestEngine.php
+++ b/src/unit/engine/TypeScriptTestEngine.php
@@ -23,7 +23,7 @@ final class TypeScriptTestEngine extends ArcanistUnitTestEngine {
     } else {
       $result->setResult(ArcanistUnitTestResult::RESULT_PASS);
     }
-    $result->setUserData(join('\n', $output));
+    $result->setUserData(join("\n", $output));
     $result->setDuration($time_taken_seconds);
     return array($result);
   }


### PR DESCRIPTION
Turns out in php `'\n'` is a backslash followed by an n, not a newline.