### PR TITLE
Run full TSLint on arc diff, skip typecheck if no TS files changed

### DIFF
--- a/src/unit/engine/TypeScriptTestEngine.php
+++ b/src/unit/engine/TypeScriptTestEngine.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Unit test engine for TypeScript and TSLint. Both of these work around the
+ * fact that the lint system requires each file to be checked separately, but
+ * TypeScript typechecking has cross-file dependencies. We run TSLint as both a
+ * lint rule and a test suite since the lint system allows autofixing and the
+ * test suite covers rules that require type info.
+ */
 final class TypeScriptTestEngine extends ArcanistUnitTestEngine {
   public function getEngineConfigurationName() {
     return 'typescript';
@@ -10,22 +17,47 @@ final class TypeScriptTestEngine extends ArcanistUnitTestEngine {
   }
 
   public function run() {
+    function isTypeScript($path) {
+      return preg_match('/^.*\.tsx?$/', $path);
+    }
+    $typescriptPaths = array_filter($this->getPaths(), 'isTypeScript');
+    if (empty($typescriptPaths)) {
+      // Skip all TypeScript checking if no TypeScript files changed.
+      return array();
+    }
     $root = $this->getWorkingCopy()->getProjectRoot();
+
     $tsc = Filesystem::resolvePath('./node_modules/.bin/tsc', $root);
     $time_start_seconds = microtime(true);
-    exec(sprintf("%s --project %s --noEmit", $tsc, $root), $output, $return_var);
+    exec(sprintf("%s --project %s --noEmit", $tsc, $root), $tscOutput, $tscReturnVar);
     $time_taken_seconds = microtime(true) - $time_start_seconds;
 
-    $result = new ArcanistUnitTestResult();
-    $result->setName('TypeScript type check');
-    if ($return_var) {
-      $result->setResult(ArcanistUnitTestResult::RESULT_FAIL);
+    $tscResult = new ArcanistUnitTestResult();
+    $tscResult->setName('TypeScript type check');
+    if ($tscReturnVar) {
+      $tscResult->setResult(ArcanistUnitTestResult::RESULT_FAIL);
     } else {
-      $result->setResult(ArcanistUnitTestResult::RESULT_PASS);
+      $tscResult->setResult(ArcanistUnitTestResult::RESULT_PASS);
     }
-    $result->setUserData(join("\n", $output));
-    $result->setDuration($time_taken_seconds);
-    return array($result);
+    $tscResult->setUserData(join("\n", $tscOutput));
+    $tscResult->setDuration($time_taken_seconds);
+
+    $tslint = Filesystem::resolvePath('./node_modules/.bin/tslint', $root);
+    $time_start_seconds = microtime(true);
+    exec(sprintf("%s --project %s %s", $tslint, $root, implode(" ", $typescriptPaths)), $tslintOutput, $tslintReturnVar);
+    $time_taken_seconds = microtime(true) - $time_start_seconds;
+
+    $tslintResult = new ArcanistUnitTestResult();
+    $tslintResult->setName('TSLint with type info');
+    if ($tslintReturnVar) {
+      $tslintResult->setResult(ArcanistUnitTestResult::RESULT_FAIL);
+    } else {
+      $tslintResult->setResult(ArcanistUnitTestResult::RESULT_PASS);
+    }
+    $tslintResult->setUserData(join("\n", $tslintOutput));
+    $tslintResult->setDuration($time_taken_seconds);
+    
+    return array($tscResult, $tslintResult);
   }
 
   public function shouldEchoTestResults() {


### PR DESCRIPTION
Fixes BNCH-1998

Previously we skipped TSLint rules that require type info
(e.g. https://palantir.github.io/tslint/rules/no-void-expression/ ) and ran
typecheck even if no TypeScript files were changed. This fixes both of those.

The old system was to run TSLint as a linter and typecheck as a unit test suite,
and now we continue to run typecheck as a unit test suite, and we run TSLint
both as a linter and a unit test suite. This is redundant, but neither one is
good enough to handle everything we want:
* The lint system provides autofixes, e.g. to sort imports. However, it must be
  run on each file individually, so we need to either calculate codebase-wide
  types over and over, once per file, or we need to limit it to rules that don't
  require type info.
* The unit test system allows us to run a script on the whole codebase so we can
  efficiently run the rule requiring type info, but does not have a mechanism
  for autofixes or inline errors in phab.

We also limit TSLint checking to files that were modified.

Some timing information to motivate this decision:
* Full typecheck takes about 15 seconds.
* TSLint on the whole project takes about 6 seconds.
* TSLint with type info on one file takes about 3 seconds.
* TSLint without type info on one file takes about 0.6 seconds.

That means that using type info is significantly slower than not, and
significantly faster than a full typecheck (which surprises me). Also, limiting
the lint process to only modified files makes linting significantly faster. It
technically might miss cross-file lint errors in untouched files, but those will
be caught by CI and should be really rare.

Test Plan:
Try `arc diff` these cases:
* No TypeScript files changed. It doesn't run typecheck.
* One TypeScript file changed to add `const f = () => console.log();`. It gives
  a TSLint error for `no-void-expression`.
* Two TypeScript files with that change. Both give a TSLint error.
* One TypeScript file changed with no problems. Typecheck and lint both work.
* One TypeScript file with out-of-order imports and a `no-void-expression`
  error. It prompts to autofix the import order and gives the other error at
  unit test time.