### PR TITLE
Add a unit test engine that runs `bin/dev check`

### DIFF
--- a/src/__phutil_library_map__.php
+++ b/src/__phutil_library_map__.php
@@ -413,6 +413,7 @@ phutil_register_library_map(array(
     'ArcanistXMLLinter' => 'lint/linter/ArcanistXMLLinter.php',
     'ArcanistXMLLinterTestCase' => 'lint/linter/__tests__/ArcanistXMLLinterTestCase.php',
     'ArcanistXUnitTestResultParser' => 'unit/parser/ArcanistXUnitTestResultParser.php',
+    'BenchlingCheckTestEngine' => 'unit/engine/BenchlingCheckTestEngine.php',
     'CSharpToolsTestEngine' => 'unit/engine/CSharpToolsTestEngine.php',
     'NoseTestEngine' => 'unit/engine/NoseTestEngine.php',
     'PhpunitTestEngine' => 'unit/engine/PhpunitTestEngine.php',
@@ -428,7 +429,10 @@ phutil_register_library_map(array(
     'XUnitTestEngine' => 'unit/engine/XUnitTestEngine.php',
     'XUnitTestResultParserTestCase' => 'unit/parser/__tests__/XUnitTestResultParserTestCase.php',
   ),
-  'function' => array(),
+  'function' => array(
+    'isTypeScript' => 'unit/engine/TypeScriptTestEngine.php',
+    'quote' => 'unit/engine/BenchlingCheckTestEngine.php',
+  ),
   'xmap' => array(
     'ArcanistAbstractMethodBodyXHPASTLinterRule' => 'ArcanistXHPASTLinterRule',
     'ArcanistAbstractMethodBodyXHPASTLinterRuleTestCase' => 'ArcanistXHPASTLinterRuleTestCase',
@@ -834,6 +838,7 @@ phutil_register_library_map(array(
     'ArcanistXMLLinter' => 'ArcanistLinter',
     'ArcanistXMLLinterTestCase' => 'ArcanistLinterTestCase',
     'ArcanistXUnitTestResultParser' => 'Phobject',
+    'BenchlingCheckTestEngine' => 'ArcanistUnitTestEngine',
     'CSharpToolsTestEngine' => 'XUnitTestEngine',
     'NoseTestEngine' => 'ArcanistUnitTestEngine',
     'PhpunitTestEngine' => 'ArcanistUnitTestEngine',

--- a/src/unit/engine/BenchlingCheckTestEngine.php
+++ b/src/unit/engine/BenchlingCheckTestEngine.php
@@ -1,0 +1,42 @@
+<?php
+
+final class BenchlingCheckTestEngine extends ArcanistUnitTestEngine {
+  public function getEngineConfigurationName() {
+    return 'benchling-check';
+  }
+
+  protected function supportsRunAllTests() {
+    return true;
+  }
+
+  public function run() {
+    function quote($s) {
+      return sprintf('"%s"', $s);
+    }
+
+    $root = $this->getWorkingCopy()->getProjectRoot();
+
+    $binDev = Filesystem::resolvePath('./bin/dev', $root);
+    $timeStartSeconds = microtime(true);
+
+    $quotedPaths = implode(" ", array_map("quote", $this->getPaths()));
+    // Pass --arc in case the script wants to behave differently when run from arc.
+    passthru(sprintf("%s check --arc %s", $binDev, $quotedPaths),$checkReturnVar);
+    $time_taken_seconds = microtime(true) - $timeStartSeconds;
+
+    $checkResult = new ArcanistUnitTestResult();
+    $checkResult->setName('bin/dev check');
+    if ($checkReturnVar) {
+      $checkResult->setResult(ArcanistUnitTestResult::RESULT_FAIL);
+    } else {
+      $checkResult->setResult(ArcanistUnitTestResult::RESULT_PASS);
+    }
+    $checkResult->setDuration($time_taken_seconds);
+
+    return array($checkResult);
+  }
+
+  public function shouldEchoTestResults() {
+    return false;
+  }
+}


### PR DESCRIPTION
The plan is to replace most our linting/checking via arc with our own script called
`bin/dev check`, which should allow for better performance and give us more
flexibility. This change just adds a simple arc wrapper that calls through to that
script, and a future aurelia commit will reconfigure aurelia to use that script instead
of the other linting.

More details in this quip doc: https://benchling.quip.com/enjVAikYgEq2/2018-07-03-Making-arc-diff-faster

This is based off of the TypeScriptTestEngine that I wrote earlier, but now just
runs a command of the form `bin/dev check --arc file1.js file2.py`. The actual
`bin/dev check` command will be added to aurelia in a later commit, but this is
needed for a smooth transition.